### PR TITLE
Don't recycle bitmaps on other threads

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/TilesOverlay.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/TilesOverlay.java
@@ -11,6 +11,7 @@ import android.graphics.Shader;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.Looper;
 import android.util.Log;
 import com.mapbox.mapboxsdk.tileprovider.MapTile;
 import com.mapbox.mapboxsdk.tileprovider.MapTileLayerBase;
@@ -21,6 +22,8 @@ import com.mapbox.mapboxsdk.views.MapView;
 import com.mapbox.mapboxsdk.views.safecanvas.ISafeCanvas;
 import com.mapbox.mapboxsdk.views.safecanvas.SafePaint;
 import com.mapbox.mapboxsdk.views.util.Projection;
+
+import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import uk.co.senab.bitmapcache.CacheableBitmapDrawable;
 
@@ -318,6 +321,13 @@ public class TilesOverlay extends SafeDrawOverlay {
         // Only recycle if we are running on a project less than 2.3.3 Gingerbread.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
             if (mLoadingTileBitmap != null) {
+                final Thread thread = Thread.currentThread();
+                Log.w(TAG, "Recycle on thread: " + thread);
+                if (thread == Looper.getMainLooper().getThread()) {
+                    mLoadingTileBitmap.recycle();
+                } else {
+                    throw new ConcurrentModificationException("Don't recycle bitmaps on other threads!");
+                }
                 mLoadingTileBitmap = null;
             }
         }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/TilesOverlay.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/TilesOverlay.java
@@ -318,7 +318,6 @@ public class TilesOverlay extends SafeDrawOverlay {
         // Only recycle if we are running on a project less than 2.3.3 Gingerbread.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
             if (mLoadingTileBitmap != null) {
-                mLoadingTileBitmap.recycle();
                 mLoadingTileBitmap = null;
             }
         }

--- a/MapboxAndroidSDK/src/main/java/uk/co/senab/bitmapcache/CacheableBitmapDrawable.java
+++ b/MapboxAndroidSDK/src/main/java/uk/co/senab/bitmapcache/CacheableBitmapDrawable.java
@@ -252,7 +252,6 @@ public class CacheableBitmapDrawable extends BitmapDrawable {
                 // Record the current method stack just in case
                 mStackTraceWhenRecycled = new Throwable("Recycled Bitmap Method Stack");
 
-                getBitmap().recycle();
             } else {
                 if (Constants.DEBUG) {
                     Log.d(LOG_TAG,

--- a/MapboxAndroidSDK/src/main/java/uk/co/senab/bitmapcache/CacheableBitmapDrawable.java
+++ b/MapboxAndroidSDK/src/main/java/uk/co/senab/bitmapcache/CacheableBitmapDrawable.java
@@ -24,6 +24,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import java.util.ConcurrentModificationException;
+
 public class CacheableBitmapDrawable extends BitmapDrawable {
 
     public static final int SOURCE_UNKNOWN = -1;
@@ -252,6 +254,13 @@ public class CacheableBitmapDrawable extends BitmapDrawable {
                 // Record the current method stack just in case
                 mStackTraceWhenRecycled = new Throwable("Recycled Bitmap Method Stack");
 
+                final Thread thread = Thread.currentThread();
+                Log.w("CacheableBitmapDrawable", "Recycle on thread: " + thread);
+                if (thread == Looper.getMainLooper().getThread()) {
+                    getBitmap().recycle();
+                } else {
+                    throw new ConcurrentModificationException("Don't recycle bitmaps on other threads!");
+                }
             } else {
                 if (Constants.DEBUG) {
                     Log.d(LOG_TAG,


### PR DESCRIPTION
There is a race condition here which may lead to a `Bitmap` being recycled on another thread while it is being drawn. This causes a native crash (`signal 11 (SIGSEGV)`) within `libskia.so`.

To reproduce the crash, use a map with satellite image tiles (necessary?) (you also may need some overlays and UI chrome floating around, I haven't tested in other scenarios) on an Android emulator running Gingerbread. I used the Nexus S device template. Perform some intensive tasks on the main thread as well, just in case (lots of layout, etc). If you move the map a lot, you will eventually experience the crash. The crash no longer occurs after removing the explicit calls to `Bitmap#recycle`.

This is not so much a solution to the problem as it is a proof that the problem exists. I will have to look into it more thoroughly to determine a better fix, since the `Bitmap`s should still be recycled, just not another thread.
